### PR TITLE
fix: season number for named seasons

### DIFF
--- a/components/ItemCardText.tsx
+++ b/components/ItemCardText.tsx
@@ -8,17 +8,6 @@ type ItemCardProps = {
   item: BaseItemDto;
 };
 
-function seasonNameToIndex(seasonName: string | null | undefined) {
-  if (!seasonName) return -1;
-  if (seasonName.startsWith("Season")) {
-    return parseInt(seasonName.replace("Season ", ""));
-  }
-  if (seasonName.startsWith("Specials")) {
-    return 0;
-  }
-  return -1;
-}
-
 export const ItemCardText: React.FC<ItemCardProps> = ({ item }) => {
   return (
     <View className="mt-2 flex flex-col h-12">
@@ -28,9 +17,7 @@ export const ItemCardText: React.FC<ItemCardProps> = ({ item }) => {
             {item.SeriesName}
           </Text>
           <Text numberOfLines={1} className="text-xs opacity-50">
-            {`S${seasonNameToIndex(
-              item?.SeasonName,
-            )}:E${item.IndexNumber?.toString()}`}{" "}
+            {`S${item.ParentIndexNumber?.toString()}:E${item.IndexNumber?.toString()}`}{" "}
             {item.Name}
           </Text>
         </>


### PR DESCRIPTION
The old fix wasn't very robust, and would break for seasons that had unexpected names.