### PR TITLE
Removed resumable items from next up

### DIFF
--- a/app/(auth)/(tabs)/(home)/index.tsx
+++ b/app/(auth)/(tabs)/(home)/index.tsx
@@ -241,6 +241,7 @@ export default function index() {
               fields: ["MediaSourceCount"],
               limit: 20,
               enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+              enableResumable: false,
             })
           ).data.Items || [],
         type: "ScrollingCollectionList",


### PR DESCRIPTION
I got really annoyed that the app kept showing resumed items in 'continue watching' and also in 'next up'.

This change will remove that issue

Before:

![image](https://github.com/user-attachments/assets/5408964a-ec8c-42f6-a686-a94a93c0083d)


After:

![image](https://github.com/user-attachments/assets/b7ec2b98-6057-4e33-9084-4d83c6ef79cb)
