### PR TITLE
Update visual playback when exiting video

### DIFF
--- a/app/(auth)/play-video.tsx
+++ b/app/(auth)/play-video.tsx
@@ -131,15 +131,12 @@ export default function page() {
       queryKey: ["seasons"],
     });
     queryClient.invalidateQueries({
-      queryKey: ["nextUp-all"],
-    });
-    queryClient.invalidateQueries({
       queryKey: ["home"],
     });
     setIsPlaybackStopped(true);
     videoRef.current?.pause();
     reportPlaybackStopped();
-  }, [videoRef]);
+  }, [queryClient, videoRef]);
 
   const reportPlaybackStopped = async () => {
     await getPlaystateApi(api).onPlaybackStopped({

--- a/app/(auth)/play-video.tsx
+++ b/app/(auth)/play-video.tsx
@@ -15,6 +15,7 @@ import { getAuthHeaders } from "@/utils/jellyfin/jellyfin";
 import { secondsToTicks } from "@/utils/secondsToTicks";
 import { Api } from "@jellyfin/sdk";
 import { getPlaystateApi } from "@jellyfin/sdk/lib/utils/api";
+import { useQueryClient } from "@tanstack/react-query";
 import * as Haptics from "expo-haptics";
 import { useFocusEffect } from "expo-router";
 import { useAtomValue } from "jotai";
@@ -105,7 +106,36 @@ export default function page() {
     videoRef.current?.pause();
   }, [videoRef]);
 
+  const queryClient = useQueryClient();
+
   const stop = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: ["item", playSettings?.item?.Id],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["resumeItems"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["continueWatching"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["nextUp-all"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["nextUp"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["episodes"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["seasons"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["nextUp-all"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["home"],
+    });
     setIsPlaybackStopped(true);
     videoRef.current?.pause();
     reportPlaybackStopped();

--- a/components/PlayedStatus.tsx
+++ b/components/PlayedStatus.tsx
@@ -42,9 +42,6 @@ export const PlayedStatus: React.FC<Props> = ({ item, ...props }) => {
       queryKey: ["seasons"],
     });
     queryClient.invalidateQueries({
-      queryKey: ["nextUp-all"],
-    });
-    queryClient.invalidateQueries({
       queryKey: ["home"],
     });
   };


### PR DESCRIPTION
This PR addresses an issue where the frontend UI was not updating instantly when a video stops playing. The changes ensure that the relevant queries are invalidated correctly, triggering an immediate UI update.

Note:

The new lines were just copied from the PlayedStatus.tsx file, this code could be refactored so that way both these two components could use one function. Please add a comment if you would like this.

## Summary by Sourcery

Bug Fixes:
- Ensure the frontend UI updates instantly when a video stops playing by invalidating relevant queries.