### PR TITLE
feat: Hide 0h on play button when media length is lower than an hour

### DIFF
--- a/utils/time.ts
+++ b/utils/time.ts
@@ -16,7 +16,8 @@ export const runtimeTicksToMinutes = (
   const hours = Math.floor(ticks / ticksPerHour);
   const minutes = Math.floor((ticks % ticksPerHour) / ticksPerMinute);
 
-  return `${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  else return `${minutes}m`;
 };
 
 export const runtimeTicksToSeconds = (


### PR DESCRIPTION
Title says it all. Will address #153.

**Before**
<img src="https://github.com/user-attachments/assets/8b510534-5030-4261-a047-203a857ebab9" width="300">

**After**
<img src="https://github.com/user-attachments/assets/a763e8ae-5c1e-4171-9709-ab725f152632" width="300">

## Summary by Sourcery

New Features:
- Hide the hour component on the play button when the media length is less than an hour.