### PR TITLE
Add MacOS fullscreen support

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
         "NSLocalNetworkUsageDescription": "The app needs access to your local network to connect to your Jellyfin server.",
         "NSAppTransportSecurity": {
           "NSAllowsArbitraryLoads": true
-        }
+        },
+        "UISupportsTrueScreenSizeOnMac": true
       },
       "config": {
         "usesNonExemptEncryption": false


### PR DESCRIPTION
**Summary:**
Added support for macOS to use true screen size with `UISupportsTrueScreenSizeOnMac: true`. This enables the app to fully utilize custom resolutions and fullscreen mode on macOS, enhancing the viewing experience for users. 

**Change:**
- Set `UISupportsTrueScreenSizeOnMac` to `true` to enable native fullscreen and resolution support on macOS.

**Testing:**
Tested on an M1 Mac to confirm the app utilizes full-screen mode and native resolutions as expected on macOS.