### PR TITLE
Added change to show actual device name rather than platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-native-bottom-tabs": "^0.4.0",
     "react-native-circular-progress": "^1.4.1",
     "react-native-compressor": "^1.9.0",
+    "react-native-device-info": "^14.0.1",
     "react-native-edge-to-edge": "^1.1.1",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-get-random-values": "^1.11.0",

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -18,6 +18,7 @@ import React, {
 } from "react";
 import { Platform } from "react-native";
 import uuid from "react-native-uuid";
+import { getDeviceName } from "react-native-device-info";
 
 interface Server {
   address: string;
@@ -49,11 +50,15 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
   useEffect(() => {
     (async () => {
       const id = getOrSetDeviceId();
+      const deviceName = await getDeviceName();
       setJellyfin(
         () =>
           new Jellyfin({
             clientInfo: { name: "Streamyfin", version: "0.21.0" },
-            deviceInfo: { name: Platform.OS === "ios" ? "iOS" : "Android", id },
+            deviceInfo: {
+              name: deviceName,
+              id,
+            },
           })
       );
       setDeviceId(id);


### PR DESCRIPTION
Instead of showing the platform on the device it now shows the actual device name on the jellyfin admin dashboard.

## Summary by Sourcery

Update the JellyfinProvider to display the actual device name on the admin dashboard by using the 'react-native-device-info' library.

New Features:
- Display the actual device name on the Jellyfin admin dashboard instead of the platform name.

Enhancements:
- Integrate the 'react-native-device-info' library to retrieve the actual device name.