### PR TITLE
New delete options & storage visibility

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tsx
@@ -132,19 +132,22 @@ export default function settings() {
 
         <View className="flex flex-col space-y-2">
           <Text className="font-bold text-lg mb-2">Storage</Text>
-          <Progress.Bar
-            className="bg-gray-100/10"
-            indeterminate={appSizeLoading}
-            color="#9333ea"
-            width={null}
-            height={10}
-            borderRadius={6}
-            borderWidth={0}
-            progress={size?.used}
-          />
-          {size && (
-            <Text>Available: {bytesToReadable(size.remaining)}, Total: {bytesToReadable(size.total)}</Text>
-          )}
+          <View className="mb-4 space-y-2">
+            {size && <Text>App usage: {bytesToReadable(size.app)}</Text>}
+            <Progress.Bar
+              className="bg-gray-100/10"
+              indeterminate={appSizeLoading}
+              color="#9333ea"
+              width={null}
+              height={10}
+              borderRadius={6}
+              borderWidth={0}
+              progress={size?.used}
+            />
+            {size && (
+              <Text>Available: {bytesToReadable(size.remaining)}, Total: {bytesToReadable(size.total)}</Text>
+            )}
+          </View>
           <Button
             color="red"
             onPress={onDeleteClicked}


### PR DESCRIPTION
integrates feature #237

# Changes

- Added react-native-progress dependency
- Added bottom sheet to downloads page to handle actions for deleting items by type
- Added ability to long press to delete a single series
- Added ability to delete by season
- Refactored delete helpers in DownloadProvider.tsx
- Display storage usage inside downloads & settings page
- Fixed Delete all downloaded files from delting user data in mmkv

## UI Changes

### Storage usage in settings page
<img src="https://github.com/user-attachments/assets/c0ad030b-4540-4405-b871-cefc189dc137"  width="300" />

### Overall downloaded items size (top right corner)
<img src="https://github.com/user-attachments/assets/d17d6116-7914-4af3-a6ff-f7df4f8bfc5f"  width="300" />

### Downloaded item actions (press size in top right corner)
<img src="https://github.com/user-attachments/assets/ccd0c71f-c368-4a8a-aef9-d1c1875ad5e8"  width="300" />

### Delete by series (long press)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b764111c-a229-4140-8c7a-132df434bba4">







---
## Summary by Sourcery

Add new delete options for media types and display storage usage in settings. Fix a bug related to deleting user data. Refactor delete helpers for better code management and add a new dependency for progress display.

New Features:
- Introduce a bottom sheet on the downloads page to manage deletion actions by type.
- Display storage usage information on the settings page.

Bug Fixes:
- Fix the issue where deleting all downloaded files also deleted user data in mmkv.

Enhancements:
- Refactor delete helpers in DownloadProvider.tsx to improve code organization and error handling.

Build:
- Add react-native-progress dependency to the project.