### PR TITLE
Multiple Remux downloads

### DIFF
--- a/components/downloads/ActiveDownloads.tsx
+++ b/components/downloads/ActiveDownloads.tsx
@@ -40,7 +40,7 @@ export const ActiveDownloads: React.FC<Props> = ({ ...props }) => {
       <Text className="text-lg font-bold mb-2">Active downloads</Text>
       <View className="space-y-2">
         {processes?.map((p) => (
-          <DownloadCard key={p.id} process={p} />
+          <DownloadCard key={p.item.Id} process={p} />
         ))}
       </View>
     </View>
@@ -77,7 +77,7 @@ const DownloadCard = ({ process, ...props }: DownloadCardProps) => {
           await queryClient.refetchQueries({ queryKey: ["jobs"] });
         }
       } else {
-        FFmpegKit.cancel();
+        FFmpegKit.cancel(Number(id));
         setProcesses((prev) => prev.filter((p) => p.id !== id));
       }
     },

--- a/components/inputs/Stepper.tsx
+++ b/components/inputs/Stepper.tsx
@@ -1,0 +1,44 @@
+import {TouchableOpacity, View} from "react-native";
+import {Text} from "@/components/common/Text";
+
+interface StepperProps {
+  value: number,
+  step: number,
+  min: number,
+  max: number,
+  onUpdate: (value: number) => void,
+  appendValue?: string,
+}
+
+export const Stepper: React.FC<StepperProps> = ({
+  value,
+  step,
+  min,
+  max,
+  onUpdate,
+  appendValue
+}) => {
+  return (
+    <View className="flex flex-row items-center">
+      <TouchableOpacity
+        onPress={() => onUpdate(Math.max(min, value - step))}
+        className="w-8 h-8 bg-neutral-800 rounded-l-lg flex items-center justify-center"
+      >
+        <Text>-</Text>
+      </TouchableOpacity>
+      <Text
+        className={
+          "w-auto h-8 bg-neutral-800 py-2 px-1 flex items-center justify-center" + (appendValue ? "first-letter:px-2" : "")
+        }
+      >
+        {value}{appendValue}
+      </Text>
+      <TouchableOpacity
+        className="w-8 h-8 bg-neutral-800 rounded-r-lg flex items-center justify-center"
+        onPress={() => onUpdate(Math.min(max, value + step))}
+      >
+        <Text>+</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}

--- a/components/settings/SettingToggles.tsx
+++ b/components/settings/SettingToggles.tsx
@@ -4,7 +4,7 @@ import {
   getOrSetDeviceId,
   userAtom,
 } from "@/providers/JellyfinProvider";
-import { ScreenOrientationEnum, useSettings } from "@/utils/atoms/settings";
+import {ScreenOrientationEnum, Settings, useSettings} from "@/utils/atoms/settings";
 import {
   BACKGROUND_FETCH_TASK,
   registerBackgroundFetchAsync,
@@ -17,7 +17,7 @@ import * as BackgroundFetch from "expo-background-fetch";
 import * as ScreenOrientation from "expo-screen-orientation";
 import * as TaskManager from "expo-task-manager";
 import { useAtom } from "jotai";
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import {
   Linking,
   Switch,
@@ -32,6 +32,7 @@ import { Input } from "../common/Input";
 import { Text } from "../common/Text";
 import { Loader } from "../Loader";
 import { MediaToggles } from "./MediaToggles";
+import {Stepper} from "@/components/inputs/Stepper";
 
 interface Props extends ViewProps {}
 
@@ -483,7 +484,44 @@ export const SettingToggles: React.FC<Props> = ({ ...props }) => {
               </DropdownMenu.Content>
             </DropdownMenu.Root>
           </View>
-          <View className="flex flex-row space-x-2 items-center justify-between bg-neutral-900 p-4">
+          <View
+            pointerEvents={
+              settings.downloadMethod === "remux" ? "auto" : "none"
+            }
+            className={`
+              flex flex-row space-x-2 items-center justify-between bg-neutral-900 p-4
+              ${
+              settings.downloadMethod === "remux"
+                ? "opacity-100"
+                : "opacity-50"
+            }`}
+          >
+            <View className="flex flex-col shrink">
+              <Text className="font-semibold">Remux max download</Text>
+              <Text className="text-xs opacity-50 shrink">
+                This is the total media you want to be able to download at the same time.
+              </Text>
+            </View>
+            <Stepper
+              value={settings.remuxConcurrentLimit}
+              step={1}
+              min={1}
+              max={4}
+              onUpdate={(value) => updateSettings({remuxConcurrentLimit: value as Settings["remuxConcurrentLimit"]})}
+            />
+          </View>
+          <View
+            pointerEvents={
+              settings.downloadMethod === "optimized" ? "auto" : "none"
+            }
+            className={`
+              flex flex-row space-x-2 items-center justify-between bg-neutral-900 p-4
+              ${
+              settings.downloadMethod === "optimized"
+                ? "opacity-100"
+                : "opacity-50"
+            }`}
+          >
             <View className="flex flex-col shrink">
               <Text className="font-semibold">Auto download</Text>
               <Text className="text-xs opacity-50 shrink">

--- a/providers/DownloadProvider.tsx
+++ b/providers/DownloadProvider.tsx
@@ -30,7 +30,7 @@ import {
 import axios from "axios";
 import * as FileSystem from "expo-file-system";
 import { useRouter } from "expo-router";
-import { useAtom } from "jotai";
+import {atom, useAtom} from "jotai";
 import React, {
   createContext,
   useCallback,
@@ -56,6 +56,8 @@ export type DownloadedItem = {
   size: number | undefined;
 };
 
+export const processesAtom = atom<JobStatus[]>([])
+
 function onAppStateChange(status: AppStateStatus) {
   focusManager.setFocused(status === "active");
 }
@@ -74,7 +76,7 @@ function useDownloadProvider() {
   const {saveSeriesPrimaryImage} = useDownloadHelper();
   const { saveImage } = useImageStorage();
 
-  const [processes, setProcesses] = useState<JobStatus[]>([]);
+  const [processes, setProcesses] = useAtom<JobStatus[]>(processesAtom);
 
   const authHeader = useMemo(() => {
     return api?.accessToken;

--- a/utils/atoms/queue.ts
+++ b/utils/atoms/queue.ts
@@ -1,6 +1,9 @@
 import { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { atom, useAtom } from "jotai";
 import { useEffect } from "react";
+import {JobStatus} from "@/utils/optimize-server";
+import {processesAtom} from "@/providers/DownloadProvider";
+import {useSettings} from "@/utils/atoms/settings";
 
 export interface Job {
   id: string;
@@ -49,11 +52,13 @@ export const queueActions = {
 export const useJobProcessor = () => {
   const [queue, setQueue] = useAtom(queueAtom);
   const [running, setRunning] = useAtom(runningAtom);
+  const [processes] = useAtom<JobStatus[]>(processesAtom);
+  const [settings] = useSettings();
 
   useEffect(() => {
-    if (queue.length > 0 && !running) {
+    if (queue.length > 0 && settings && processes.length < settings?.remuxConcurrentLimit) {
       console.info("Processing queue", queue);
       queueActions.processJob(queue, setQueue, setRunning);
     }
-  }, [queue, running, setQueue, setRunning]);
+  }, [processes, queue, running, setQueue, setRunning]);
 };

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -75,6 +75,7 @@ export type Settings = {
   downloadMethod: "optimized" | "remux";
   autoDownload: boolean,
   showCustomMenuLinks: boolean;
+  remuxConcurrentLimit: 1 | 2 | 3 | 4; // TODO: Maybe let people choose their own limit? 4 seems like a safe max?
 };
 
 const loadSettings = (): Settings => {
@@ -105,6 +106,7 @@ const loadSettings = (): Settings => {
     downloadMethod: "remux",
     autoDownload: false,
     showCustomMenuLinks: false,
+    remuxConcurrentLimit: 1,
   };
 
   try {

--- a/utils/log.tsx
+++ b/utils/log.tsx
@@ -55,6 +55,9 @@ export const writeToLog = (level: LogLevel, message: string, data?: any) => {
   storage.set("logs", JSON.stringify(recentLogs));
 };
 
+export const writeInfoLog = (message: string, data?: any) => writeToLog("INFO", message, data);
+export const writeErrorLog = (message: string, data?: any) => writeToLog("ERROR", message, data);
+
 export const readFromLog = (): LogEntry[] => {
   const logs = storage.getString("logs");
   return logs ? JSON.parse(logs) : [];


### PR DESCRIPTION
# Changes

- Added stepper component
- Disabled more download settings based on download method
- refactored useRemuxHlsToMp4.ts to allow for multiple remux downloads

## UI Changes

### New remux download settings
<img src="https://github.com/user-attachments/assets/677cebe9-1ed3-47f1-af28-56b66b3abdaa" width="300"/>

### Multiple downloads using remux
<img src="https://github.com/user-attachments/assets/0ffb9172-4990-494a-8c48-37305020e01d" width="300"/>

## Summary by Sourcery

Add support for multiple remux downloads and introduce a stepper component for UI settings adjustments. Refactor the useRemuxHlsToMp4 hook to handle concurrent downloads and improve logging mechanisms.

New Features:
- Introduce a stepper component for adjusting settings in the UI.
- Enable multiple remux downloads by refactoring the useRemuxHlsToMp4 hook.

Enhancements:
- Refactor useRemuxHlsToMp4 to support concurrent remux downloads and improve logging.