### PR TITLE
Prefetch trick-play images

### DIFF
--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -113,10 +113,12 @@ export const Controls: React.FC<Props> = ({
   const insets = useSafeAreaInsets();
 
   const { previousItem, nextItem } = useAdjacentItems({ item });
-  const { trickPlayUrl, calculateTrickplayUrl, trickplayInfo } = useTrickplay(
-    item,
-    !offline && enableTrickplay
-  );
+  const {
+    trickPlayUrl,
+    calculateTrickplayUrl,
+    trickplayInfo,
+    prefetchAllTrickplayImages,
+  } = useTrickplay(item, !offline && enableTrickplay);
 
   const [currentTime, setCurrentTime] = useState(0);
   const [remainingTime, setRemainingTime] = useState(0);
@@ -238,6 +240,10 @@ export const Controls: React.FC<Props> = ({
         : item.RunTimeTicks || 0;
     }
   }, [item, isVlc]);
+
+  useEffect(() => {
+    prefetchAllTrickplayImages();
+  }, []);
 
   const toggleControls = () => setShowControls(!showControls);
 


### PR DESCRIPTION
Added feature to prefetch trick-play images on video start rather than downloading it while scrubbing.

May have to revisit to prefetch on ItemContentView depending on how actual device testing goes.

## Summary by Sourcery

New Features:
- Add prefetching of trick-play images at video start to improve scrubbing performance.