### PR TITLE
Made pause video on app exit and added some performance changes for android

### DIFF
--- a/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerModule.kt
+++ b/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerModule.kt
@@ -9,9 +9,7 @@ class VlcPlayerModule : Module() {
 
     View(VlcPlayerView::class) {
       Prop("source") { view: VlcPlayerView, source: Map<String, Any> ->
-        if (!view.hasSource) {
-          view.setSource(source)
-        }
+        view.setSource(source)
       }
 
       Prop("paused") { view: VlcPlayerView, paused: Boolean ->

--- a/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerModule.kt
+++ b/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerModule.kt
@@ -9,7 +9,9 @@ class VlcPlayerModule : Module() {
 
     View(VlcPlayerView::class) {
       Prop("source") { view: VlcPlayerView, source: Map<String, Any> ->
-        view.setSource(source)
+        if (!view.hasSource) {
+          view.setSource(source)
+        }
       }
 
       Prop("paused") { view: VlcPlayerView, paused: Boolean ->

--- a/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerView.kt
+++ b/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerView.kt
@@ -265,7 +265,6 @@ class VlcPlayerView(context: Context, appContext: AppContext) : ExpoView(context
 
         val currentTimeMs = player.time.toInt()
         val durationMs = player.media?.duration?.toInt() ?: 0
-        println("isPlayer Attached: ${videoLayout.isAttachedToWindow}")
         if (currentTimeMs >= 0 && currentTimeMs < durationMs) {
             // Set subtitle URL if available
             if (player.isPlaying && !isMediaReady) {

--- a/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerView.kt
+++ b/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerView.kt
@@ -60,6 +60,11 @@ class VlcPlayerView(context: Context, appContext: AppContext) : ExpoView(context
     }
 
     fun setSource(source: Map<String, Any>) {
+        if (hasSource) {
+            mediaPlayer?.attachViews(videoLayout, null, false, false)
+            play()
+            return
+        }
         val mediaOptions = source["mediaOptions"] as? Map<String, Any> ?: emptyMap()
         val autoplay = source["autoplay"] as? Boolean ?: false
         val isNetwork = source["isNetwork"] as? Boolean ?: false
@@ -260,7 +265,7 @@ class VlcPlayerView(context: Context, appContext: AppContext) : ExpoView(context
 
         val currentTimeMs = player.time.toInt()
         val durationMs = player.media?.duration?.toInt() ?: 0
-
+        println("isPlayer Attached: ${videoLayout.isAttachedToWindow}")
         if (currentTimeMs >= 0 && currentTimeMs < durationMs) {
             // Set subtitle URL if available
             if (player.isPlaying && !isMediaReady) {

--- a/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerView.kt
+++ b/modules/vlc-player/android/src/main/java/expo/modules/vlcplayer/VlcPlayerView.kt
@@ -32,6 +32,7 @@ class VlcPlayerView(context: Context, appContext: AppContext) : ExpoView(context
     private var startPosition: Int? = 0
     private var isMediaReady: Boolean = false
     private var externalTrack: Map<String, String>? = null
+    var hasSource: Boolean = false
 
     init {
         setupView()
@@ -87,6 +88,7 @@ class VlcPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         //     Log.d("VlcPlayerView", "Debug: Subtitle track index is less than -1, not setting")
         // }
 
+        hasSource = true
 
         if (autoplay) {
             Log.d("VlcPlayerView", "Playing...")

--- a/modules/vlc-player/ios/VlcPlayerModule.swift
+++ b/modules/vlc-player/ios/VlcPlayerModule.swift
@@ -5,7 +5,9 @@ public class VlcPlayerModule: Module {
         Name("VlcPlayer")
         View(VlcPlayerView.self) {
             Prop("source") { (view: VlcPlayerView, source: [String: Any]) in
-                view.setSource(source)
+                if !view.hasSource {
+                    view.setSource(source)
+                }
             }
 
             Prop("paused") { (view: VlcPlayerView, paused: Bool) in

--- a/modules/vlc-player/ios/VlcPlayerView.swift
+++ b/modules/vlc-player/ios/VlcPlayerView.swift
@@ -16,6 +16,7 @@ class VlcPlayerView: ExpoView {
     private var externalTrack: [String: String]?
     private var progressTimer: DispatchSourceTimer?
     private var isStopping: Bool = false  // Define isStopping here
+    var hasSource = false
 
     // MARK: - Initialization
 
@@ -157,6 +158,7 @@ class VlcPlayerView: ExpoView {
             self.setSubtitleTrack(subtitleTrackIndex)
 
             self.mediaPlayer?.media = media
+            hasSource = true
 
             if autoplay {
                 print("Playing...")
@@ -280,15 +282,11 @@ class VlcPlayerView: ExpoView {
     // MARK: - Private Methods
 
     @objc private func applicationWillResignActive() {
-        if !isPaused {
-            pause()
-        }
+
     }
 
     @objc private func applicationDidBecomeActive() {
-        if !isPaused {
-            play()
-        }
+
     }
 
     private func performStop(completion: (() -> Void)? = nil) {

--- a/modules/vlc-player/ios/VlcPlayerView.swift
+++ b/modules/vlc-player/ios/VlcPlayerView.swift
@@ -15,6 +15,7 @@ class VlcPlayerView: ExpoView {
     private var isMediaReady: Bool = false
     private var externalTrack: [String: String]?
     private var progressTimer: DispatchSourceTimer?
+    private var isStopping: Bool = false  // Define isStopping here
 
     // MARK: - Initialization
 
@@ -50,8 +51,8 @@ class VlcPlayerView: ExpoView {
             self, selector: #selector(applicationWillResignActive),
             name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(
-            self, selector: #selector(applicationWillEnterForeground),
-            name: UIApplication.willEnterForegroundNotification, object: nil)
+            self, selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     private func setupProgressTimer() {
@@ -259,8 +260,6 @@ class VlcPlayerView: ExpoView {
         print("Track not found for name: \(trackName)")
     }
 
-    private var isStopping: Bool = false
-
     @objc func stop(completion: (() -> Void)? = nil) {
         guard !isStopping else {
             completion?()
@@ -286,7 +285,7 @@ class VlcPlayerView: ExpoView {
         }
     }
 
-    @objc private func applicationWillEnterForeground() {
+    @objc private func applicationDidBecomeActive() {
         if !isPaused {
             play()
         }


### PR DESCRIPTION
This bug pauses the video on the exit app and fixes the issue for
- #250


Also adds performance changes for android!

## Summary by Sourcery

Bug Fixes:
- Fix video playback issue by pausing the video when the app goes to the background on iOS.