### PR TITLE
Fix delete by show file type

### DIFF
--- a/app/(auth)/(tabs)/(home)/downloads/index.tsx
+++ b/app/(auth)/(tabs)/(home)/downloads/index.tsx
@@ -71,7 +71,7 @@ export default function page() {
       writeToLog("ERROR", reason);
       toast.error("Failed to delete all movies");
     });
-  const deleteShows = () => deleteFileByType("Movie")
+  const deleteShows = () => deleteFileByType("Episode")
     .then(() => toast.success("Deleted all TV-Series successfully!"))
     .catch((reason) => {
       writeToLog("ERROR", reason);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the file type parameter in the deleteShows function to ensure it deletes TV-Series instead of Movies.