### PR TITLE
Fix default subtitles not working on app.

### DIFF
--- a/hooks/useDefaultPlaySettings.ts
+++ b/hooks/useDefaultPlaySettings.ts
@@ -17,16 +17,20 @@ const useDefaultPlaySettings = (
     // 2. Get default or preferred audio
     const defaultAudioIndex = mediaSource?.DefaultAudioStreamIndex;
     const preferedAudioIndex = mediaSource?.MediaStreams?.find(
-      (x) => x.Language === settings?.defaultAudioLanguage
+      (x) => x.Type === "Audio" && x.Language === settings?.defaultAudioLanguage
     )?.Index;
+
     const firstAudioIndex = mediaSource?.MediaStreams?.find(
       (x) => x.Type === "Audio"
     )?.Index;
 
     // 3. Get default or preferred subtitle
     const preferedSubtitleIndex = mediaSource?.MediaStreams?.find(
-      (x) => x.Language === settings?.defaultSubtitleLanguage?.value
+      (x) =>
+        x.Type === "Subtitle" &&
+        x.Language === settings?.defaultSubtitleLanguage?.value
     )?.Index;
+
     const defaultSubtitleIndex = mediaSource?.MediaStreams?.find(
       (stream) => stream.Type === "Subtitle" && stream.IsDefault
     )?.Index;
@@ -38,7 +42,9 @@ const useDefaultPlaySettings = (
       defaultAudioIndex:
         preferedAudioIndex || defaultAudioIndex || firstAudioIndex || undefined,
       defaultSubtitleIndex:
-        preferedSubtitleIndex || defaultSubtitleIndex || undefined,
+        preferedSubtitleIndex !== undefined
+          ? preferedSubtitleIndex
+          : defaultSubtitleIndex || undefined,
       defaultMediaSource: mediaSource || undefined,
       defaultBitrate: bitrate || undefined,
     };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue where default subtitles were not being selected correctly by ensuring the subtitle type is checked and the preferred subtitle index is prioritized.