### PR TITLE
Changed default subtitle size depending platform

### DIFF
--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -2,6 +2,7 @@ import { atom, useAtom } from "jotai";
 import { useEffect } from "react";
 import * as ScreenOrientation from "expo-screen-orientation";
 import { storage } from "../mmkv";
+import { Platform } from "react-native";
 
 export type DownloadQuality = "original" | "high" | "low";
 
@@ -107,7 +108,7 @@ const loadSettings = (): Settings => {
     downloadMethod: "remux",
     autoDownload: false,
     showCustomMenuLinks: false,
-    subtitleSize: 60,
+    subtitleSize: Platform.OS === "ios" ? 60 : 100,
     remuxConcurrentLimit: 1,
   };
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust subtitle size based on the platform, setting it to 60 for iOS and 100 for other platforms.