### PR TITLE
Move downloads to a cache directory

### DIFF
--- a/app/(auth)/(tabs)/(home)/index.tsx
+++ b/app/(auth)/(tabs)/(home)/index.tsx
@@ -64,7 +64,7 @@ export default function index() {
   const [isConnected, setIsConnected] = useState<boolean | null>(null);
   const [loadingRetry, setLoadingRetry] = useState(false);
 
-  const { downloadedFiles } = useDownload();
+  const { downloadedFiles, cleanCacheDirectory } = useDownload();
   const navigation = useNavigation();
 
   const insets = useSafeAreaInsets();
@@ -107,6 +107,9 @@ export default function index() {
       setIsConnected(state.isConnected);
     });
 
+    cleanCacheDirectory()
+      .then(r => console.log("Cache directory cleaned"))
+      .catch(e => console.error("Something went wrong cleaning cache directory"))
     return () => {
       unsubscribe();
     };

--- a/components/downloads/EpisodeCard.tsx
+++ b/components/downloads/EpisodeCard.tsx
@@ -91,6 +91,7 @@ export const EpisodeCard: React.FC<EpisodeCardProps> = ({ item, ...props }) => {
           <Text className="text-xs text-neutral-500">
             {runtimeTicksToSeconds(item.RunTimeTicks)}
           </Text>
+          <DownloadSize items={[item]} />
         </View>
       </View>
 


### PR DESCRIPTION
- cleanup cache during apps first cold start
- Downloads now saved in cacheDirectory and moved to documents when verified complete
- Bring back download size to episode card
- Improve reading a files size if its a known downloaded file
- Added decimal to divisor in bytesToReadable for more accurate file size conversions


## Summary by Sourcery

Enhancements:
- Move downloads to a cache directory before transferring them to the documents directory upon verification.