### PR TITLE
fix: remove deviceProfile when streaming

### DIFF
--- a/utils/jellyfin/media/getStreamUrl.ts
+++ b/utils/jellyfin/media/getStreamUrl.ts
@@ -85,7 +85,6 @@ export const getStreamUrl = async ({
     {
       method: "POST",
       data: {
-        deviceProfile,
         userId,
         maxStreamingBitrate,
         startTimeTicks,


### PR DESCRIPTION
This restores streaming functionality on iOS and android.

Have also tested it does not impact the native player / non-casting.

Solves https://github.com/fredrikburmester/streamyfin/issues/290

## Summary by Sourcery

Bug Fixes:
- Remove the deviceProfile parameter from the streaming request to restore streaming functionality on iOS and Android.