### PR TITLE
Fix merged versions showing as separate media in listings.

### DIFF
--- a/app/(auth)/(tabs)/(home,libraries,search)/collections/[collectionId].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search)/collections/[collectionId].tsx
@@ -104,9 +104,12 @@ const page: React.FC = () => {
           "CanDelete",
           "MediaSourceCount",
         ],
+        // true is needed for merged versions
+        recursive: true,
         genres: selectedGenres,
         tags: selectedTags,
         years: selectedYears.map((year) => parseInt(year)),
+        includeItemTypes: ["Movie", "Series", "MusicAlbum"],
       });
 
       return response.data || null;

--- a/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
+++ b/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
@@ -46,7 +46,7 @@ import { colletionTypeToItemType } from "@/utils/collectionTypeToItemType";
 const Page = () => {
   const searchParams = useLocalSearchParams();
   const { libraryId } = searchParams as { libraryId: string };
-
+  console.log(libraryId);
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
   const { width: screenWidth } = useWindowDimensions();
@@ -151,6 +151,8 @@ const Page = () => {
         itemType = "Movie";
       } else if (library.CollectionType === "tvshows") {
         itemType = "Series";
+      } else if (library.CollectionType === "boxsets") {
+        itemType = "BoxSet";
       }
 
       const response = await getItemsApi(api).getItems({
@@ -161,7 +163,8 @@ const Page = () => {
         sortBy: [sortBy[0], "SortName", "ProductionYear"],
         sortOrder: [sortOrder[0]],
         enableImageTypes: ["Primary", "Backdrop", "Banner", "Thumb"],
-        recursive: false,
+        // true is needed for merged versions
+        recursive: true,
         imageTypeLimit: 1,
         fields: ["PrimaryImageAspectRatio", "SortName"],
         genres: selectedGenres,

--- a/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
+++ b/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
@@ -46,7 +46,7 @@ import { colletionTypeToItemType } from "@/utils/collectionTypeToItemType";
 const Page = () => {
   const searchParams = useLocalSearchParams();
   const { libraryId } = searchParams as { libraryId: string };
-  console.log(libraryId);
+
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
   const { width: screenWidth } = useWindowDimensions();


### PR DESCRIPTION
Merged versions currently show as separate media in listings. This should fix that

## Summary by Sourcery

Fetch merged versions as a single entity in library and collection listings.

Bug Fixes:
- Fixed an issue where merged versions were showing up as separate media items in listings.

Enhancements:
- Added "BoxSet" as a valid item type.