### PR TITLE
Basic Jellyseerr discover page

### DIFF
--- a/augmentations/index.ts
+++ b/augmentations/index.ts
@@ -1,2 +1,3 @@
-export * from "./number";
 export * from "./mmkv";
+export * from "./number";
+export * from "./string";

--- a/augmentations/number.ts
+++ b/augmentations/number.ts
@@ -1,6 +1,9 @@
 declare global {
   interface Number {
     bytesToReadable(): string;
+    secondsToMilliseconds(): number
+    minutesToMilliseconds(): number
+    hoursToMilliseconds(): number
   }
 }
 
@@ -17,6 +20,18 @@ Number.prototype.bytesToReadable = function () {
   if (kb >= 1) return `${kb.toFixed(2)} KB`;
 
   return `${bytes.toFixed(2)} B`;
+}
+
+Number.prototype.secondsToMilliseconds = function () {
+  return this.valueOf() * 1000
+}
+
+Number.prototype.minutesToMilliseconds = function () {
+  return this.valueOf() * (60).secondsToMilliseconds()
+}
+
+Number.prototype.hoursToMilliseconds = function () {
+  return this.valueOf() * (60).minutesToMilliseconds()
 }
 
 export {};

--- a/augmentations/string.ts
+++ b/augmentations/string.ts
@@ -1,0 +1,16 @@
+declare global {
+  interface String {
+    toTitle(): string;
+  }
+}
+
+String.prototype.toTitle = function () {
+  return this
+    .replaceAll("_", " ")
+    .replace(
+      /\w\S*/g,
+      text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
+    );
+}
+
+export {};

--- a/components/GenreTags.tsx
+++ b/components/GenreTags.tsx
@@ -8,14 +8,26 @@ interface TagProps {
   textClass?: ViewProps["className"]
 }
 
+export const Tag: React.FC<{ text: string, textClass?: ViewProps["className"]} & ViewProps> = ({
+  text,
+  textClass,
+  ...props
+}) => {
+  return (
+    <View className="bg-neutral-800 rounded-full px-2 py-1" {...props}>
+      <Text className={textClass}>{text}</Text>
+    </View>
+  );
+};
+
 export const Tags: React.FC<TagProps & ViewProps> = ({ tags, textClass = "text-xs", ...props }) => {
   if (!tags || tags.length === 0) return null;
 
   return (
     <View className={`flex flex-row flex-wrap gap-1 ${props.className}`} {...props}>
-      {tags.map((genre, idx) => (
-        <View key={idx} className="bg-neutral-800 rounded-full px-2 py-1">
-          <Text className={textClass}>{genre}</Text>
+      {tags.map((tag, idx) => (
+        <View>
+          <Tag key={idx} textClass={textClass} text={tag}/>
         </View>
       ))}
     </View>

--- a/components/Ratings.tsx
+++ b/components/Ratings.tsx
@@ -55,7 +55,9 @@ export const JellyserrRatings: React.FC<{result: MovieResult | TvResult}> = ({ r
         ? jellyseerrApi?.movieRatings(result.id)
         : jellyseerrApi?.tvRatings(result.id)
     },
-    enabled: !!jellyseerrApi
+    staleTime: (5).minutesToMilliseconds(),
+    retry: false,
+    enabled: !!jellyseerrApi,
   });
 
   return (isLoading || !!result.voteCount ||

--- a/components/jellyseerr/DiscoverSlide.tsx
+++ b/components/jellyseerr/DiscoverSlide.tsx
@@ -1,0 +1,75 @@
+import React, {useMemo} from "react";
+import DiscoverSlider from "@/utils/jellyseerr/server/entity/DiscoverSlider";
+import {DiscoverSliderType} from "@/utils/jellyseerr/server/constants/discover";
+import {DiscoverEndpoint, Endpoints, useJellyseerr} from "@/hooks/useJellyseerr";
+import {useInfiniteQuery} from "@tanstack/react-query";
+import {MovieResult, TvResult} from "@/utils/jellyseerr/server/models/Search";
+import JellyseerrPoster from "@/components/posters/JellyseerrPoster";
+import {Text} from "@/components/common/Text";
+import {FlashList} from "@shopify/flash-list";
+
+interface Props {
+  slide: DiscoverSlider
+}
+const DiscoverSlide: React.FC<Props> = ({slide}) => {
+  const {jellyseerrApi} = useJellyseerr();
+
+  const {data, isFetching, fetchNextPage, hasNextPage} = useInfiniteQuery({
+    queryKey: ["jellyseerr", "discover", slide.id],
+    queryFn: async ({ pageParam }) => {
+      let endpoint: DiscoverEndpoint | undefined = undefined;
+      let params: any = {
+        page: Number(pageParam)
+      }
+
+      switch (slide.type) {
+        case DiscoverSliderType.TRENDING:
+          endpoint = Endpoints.DISCOVER_TRENDING;
+          break;
+        case DiscoverSliderType.POPULAR_MOVIES:
+        case DiscoverSliderType.UPCOMING_MOVIES:
+          endpoint = Endpoints.DISCOVER_MOVIES
+          if (slide.type === DiscoverSliderType.UPCOMING_MOVIES)
+            params = { ...params, primaryReleaseDateGte: new Date().toISOString().split('T')[0]}
+          break;
+        case DiscoverSliderType.POPULAR_TV:
+        case DiscoverSliderType.UPCOMING_TV:
+          endpoint = Endpoints.DISCOVER_TV
+          if (slide.type === DiscoverSliderType.UPCOMING_TV)
+            params = {...params, firstAirDateGte: new Date().toISOString().split('T')[0]}
+          break;
+      }
+
+      return endpoint ? jellyseerrApi?.discover(endpoint, params) : null;
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, pages) => ((lastPage?.page || pages?.findLast(p => p?.results.length)?.page) || 1) + 1,
+    enabled: !!jellyseerrApi,
+    staleTime: 0
+  });
+
+  const flatData = useMemo(() => data?.pages?.filter(p => p?.results.length).flatMap(p => p?.results), [data])
+
+  return (
+    (flatData && flatData?.length > 0) && <>
+      <Text className="font-bold text-lg mb-2">{DiscoverSliderType[slide.type].toString().toTitle()}</Text>
+      <FlashList
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyExtractor={item => item!!.id.toString()}
+        estimatedItemSize={250}
+        data={flatData}
+        onEndReachedThreshold={1}
+        onEndReached={() => {
+          if (hasNextPage)
+            fetchNextPage()
+        }}
+        renderItem={({item}) =>
+          (item ? <JellyseerrPoster item={item as MovieResult | TvResult} /> : <></>)
+      }
+      />
+    </>
+  )
+}
+
+export default DiscoverSlide;

--- a/components/settings/SettingToggles.tsx
+++ b/components/settings/SettingToggles.tsx
@@ -160,6 +160,9 @@ export const SettingToggles: React.FC<Props> = ({ ...props }) => {
           setJellyseerrUser(user);
           updateSettings({jellyseerrServerUrl})
         })
+        .catch(() => {
+          toast.error("Failed to login to jellyseerr!")
+        })
         .finally(() => {
           setJellyseerrPassword(undefined);
         })
@@ -725,6 +728,8 @@ export const SettingToggles: React.FC<Props> = ({ ...props }) => {
                 <Text className="text-xs opacity-50">
                   Set the URL for your jellyseerr instance.
                 </Text>
+                <Text className="text-xs text-gray-600">Example: http(s)://your-host.url</Text>
+                <Text className="text-xs text-gray-600 mb-1">(add port if required)</Text>
                 <Text className="text-xs text-red-600">This integration is in its early stages. Expect things to change.</Text>
               </View>
               <Input


### PR DESCRIPTION
# Basic Jellyseerr discover page
### based on changes #315

- Discover page will respect the ordering and type of slider you have set up in Jellyseerr.
- Decoupled library & jellyseerr results since they now have their own pages within search

Todo:
- Get genre/studio/network/tmdb sliders working


<img width="300" alt="image" src="https://github.com/user-attachments/assets/6faa6c15-4518-4075-94ec-1ecb82762430" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/dc91d458-40de-4fdc-a1fc-02d7c3f866db" />

## Summary by Sourcery

Implement a basic Jellyseerr discover page that aligns with the slider configurations in Jellyseerr. Decouple library and Jellyseerr results by providing distinct pages for each within the search functionality. Enhance the Jellyseerr API with new methods for discover settings and results, and improve utility functions with new time conversion methods and string formatting capabilities.

New Features:
- Introduce a basic Jellyseerr discover page that respects the ordering and type of slider set up in Jellyseerr.

Enhancements:
- Decouple library and Jellyseerr results by creating separate pages within the search functionality.
- Add new methods to the Jellyseerr API for fetching discover settings and results.
- Enhance number prototype with methods to convert time units to milliseconds.
- Add a new string prototype method to convert strings to title case.